### PR TITLE
Center Juice Grid Items

### DIFF
--- a/packages/nextjs/components/JuiceGrid.tsx
+++ b/packages/nextjs/components/JuiceGrid.tsx
@@ -1,7 +1,7 @@
 export const JuiceGrid = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="p-4 sm:p-6 bg-stone-700 border-4 border-stone-800 rounded-2xl shadow-inner">
-      <div className="grid grid-cols-3 gap-4 sm:gap-6">{children}</div>
+      <div className="max-w-[300px] flex flex-wrap justify-center gap-4 sm:gap-6">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
Change the `<JuiceGrid>` to use `flex` and center the items

<img width="589" alt="Screenshot 2024-11-24 at 4 03 52 AM" src="https://github.com/user-attachments/assets/6b58e562-471a-4309-a4a1-8c7b12f991ce">
